### PR TITLE
[Easy] Log pod configutation on startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,8 +77,8 @@ pub fn u256_to_f64(value: U256) -> f64 {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("Beginning service with configuration parameters {:?}", opt);
     let opt = Opt::from_args();
+    println!("Beginning service with configuration parameters {:?}", opt);
     let config: config::Config = toml::from_str(&std::fs::read_to_string(opt.config)?)?;
     println!("Monitoring accounts {:?}", config);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,8 +77,10 @@ pub fn u256_to_f64(value: U256) -> f64 {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Beginning service with configuration parameters {:?}", opt);
     let opt = Opt::from_args();
     let config: config::Config = toml::from_str(&std::fs::read_to_string(opt.config)?)?;
+    println!("Monitoring accounts {:?}", config);
 
     // web3
     let (event_loop_handle, transport) =


### PR DESCRIPTION
Previously it was very inconvenient to directly determine which accounts were being monitored while this program is running. These simple print statements provide that information as a "log" 