### PR TITLE
Allow passing custom tag label to metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ The balance information is exposed as a prometheus metric at `/metrics`. With th
 ```
 # HELP etherbalance_balance The ether or IERC20 balance of an ethereum address.
 # TYPE etherbalance_balance gauge
-etherbalance_balance{address="0x3f5ce5fbfe3e9af3971dd833d26ba9b5c936f0be",address_name="company-wallet",token_name="ether"} 208965276689158900000000
-etherbalance_balance{address="0x3f5ce5fbfe3e9af3971dd833d26ba9b5c936f0be",address_name="company-wallet",token_name="usdc"} 16234719511522
-etherbalance_balance{address="0x3f5ce5fbfe3e9af3971dd833d26ba9b5c936f0be",address_name="company-wallet",token_name="usdt"} 110017919015055
-etherbalance_balance{address="0xbe0eb53f46cd790cd13851d5eff43d12404d33e8",address_name="personal-wallet",token_name="ether"} 2318528098086858200000000
-etherbalance_balance{address="0xbe0eb53f46cd790cd13851d5eff43d12404d33e8",address_name="personal-wallet",token_name="usdc"} 49434572690562
-etherbalance_balance{address="0xbe0eb53f46cd790cd13851d5eff43d12404d33e8",address_name="personal-wallet",token_name="usdt"} 717944090350919
+etherbalance_balance{address="0x3f5ce5fbfe3e9af3971dd833d26ba9b5c936f0be",address_name="company-wallet",token_name="ether",tag=""} 208965276689158900000000
+etherbalance_balance{address="0x3f5ce5fbfe3e9af3971dd833d26ba9b5c936f0be",address_name="company-wallet",token_name="usdc",tag=""} 16234719511522
+etherbalance_balance{address="0x3f5ce5fbfe3e9af3971dd833d26ba9b5c936f0be",address_name="company-wallet",token_name="usdt",tag=""} 110017919015055
+etherbalance_balance{address="0xbe0eb53f46cd790cd13851d5eff43d12404d33e8",address_name="personal-wallet",token_name="ether",tag="tag"} 2318528098086858200000000
+etherbalance_balance{address="0xbe0eb53f46cd790cd13851d5eff43d12404d33e8",address_name="personal-wallet",token_name="usdc",tag="tag"} 49434572690562
+etherbalance_balance{address="0xbe0eb53f46cd790cd13851d5eff43d12404d33e8",address_name="personal-wallet",token_name="usdt",tag="tag"} 717944090350919
 # HELP etherbalance_last_update Unix time of last update of balances.
 # TYPE etherbalance_last_update gauge
 etherbalance_last_update 1586257843.7633243

--- a/example_config.toml
+++ b/example_config.toml
@@ -13,5 +13,7 @@ usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
 # * ether specifies whether ether balance should be monitored.
 # * tokens specifies which ERC20 tokens should be monitored. All tokens must
 #   be named in the tokens section.
-personal-wallet = { address = "0xbe0eb53f46cd790cd13851d5eff43d12404d33e8", ether=true, tokens = ["usdt", "usdc"] }
+# * tag is an optional value put into the prometheus "tag" label for the
+#   address' metric.
+personal-wallet = { address = "0xbe0eb53f46cd790cd13851d5eff43d12404d33e8", ether=true, tokens = ["usdt", "usdc"], tag = "tag" }
 company-wallet = { address = "0x3f5ce5fbfe3e9af3971dd833d26ba9b5c936f0be", ether=true, tokens = ["usdt", "usdc"] }

--- a/src/balance_monitor.rs
+++ b/src/balance_monitor.rs
@@ -20,6 +20,7 @@ pub struct CallbackParameters<'a> {
     pub address: &'a Address,
     pub token_name: &'a str,
     pub balance: Result<U256>,
+    pub tag: &'a str,
 }
 
 impl BalanceMonitor {
@@ -48,6 +49,7 @@ impl BalanceMonitor {
                     address: &address.address,
                     token_name: "ether",
                     balance: balance.map_err(Error::new),
+                    tag: &address.tag,
                 });
             }
             for token in &address.tokens {
@@ -57,6 +59,7 @@ impl BalanceMonitor {
                     address: &address.address,
                     token_name: &token.name,
                     balance: balance.map_err(Error::new),
+                    tag: &address.tag,
                 });
             }
         }
@@ -77,6 +80,7 @@ struct AddressToMonitor {
     address: Address,
     monitor_ether: bool,
     tokens: Vec<Rc<Token>>,
+    tag: String,
 }
 
 fn create_tokens(
@@ -119,6 +123,7 @@ fn create_addresses_to_monitor(
                 address: config_address.address.0,
                 monitor_ether: config_address.ether,
                 tokens: tokens?,
+                tag: config_address.tag.unwrap_or_default(),
             })
         })
         .collect()

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,7 @@ pub struct ConfigAddress {
     pub address: Address_,
     pub ether: bool,
     pub tokens: Vec<String>,
+    pub tag: Option<String>,
 }
 
 /// The user facing config file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "etherbalance_balance",
             "The ether or IERC20 balance of an ethereum address.",
         ),
-        &["address_name", "token_name", "address"],
+        &["address_name", "token_name", "address", "tag"],
     )?;
     let last_update_metric = prometheus::Gauge::new(
         "etherbalance_last_update",
@@ -135,6 +135,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         params.address_name,
                         params.token_name,
                         &format!("{:#x}", params.address),
+                        params.tag,
                     ])
                     .set(u256_to_f64(balance)),
                 Err(err) => println!(


### PR DESCRIPTION
This is useful if users for example want to set up alerts based some
custom grouping.
I originally wanted to go with totally custom tags but after
implementing it, it turned out that rust-prometheus does not support
this well. We would always need to provide all labels for every metric.
So if one address has the custom label "a=a" and another the custom label
"b=b" then we need to set both "a" and "b" for both metrics. We could
implement that but it feels annoying enough to do this easier version
instead.

Test:
Run locally and see that the tag shows up in the metrics.