### PR TITLE
Update Docker Image to use recent cargo version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM rust:1-stretch as builder
+FROM rust:1-bullseye as builder
 # Choose a workdir
 WORKDIR /usr/src/app
 # Create blank project
@@ -13,7 +13,7 @@ COPY src src
 COPY contracts contracts
 RUN touch src/main.rs && cargo build --release
 
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 RUN apt-get update && apt-get --yes install openssl
 COPY --from=builder /usr/src/app/target/release/etherbalance /bin/
 CMD etherbalance


### PR DESCRIPTION
use Debian `bullseye` instead of `stretch` (only went to v1.45).


### TestPlan

Run 
```sh
docker build --tag test:etherbalance -f docker/Dockerfile .
```
and get the following
<details><summary>Results</summary>

```
[+] Building 152.8s (17/17) FINISHED                                                                                                  
 => [internal] load build definition from Dockerfile                                                                             0.0s
 => => transferring dockerfile: 577B                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                0.0s
 => => transferring context: 2B                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/debian:bullseye-slim                                                          1.7s
 => [internal] load metadata for docker.io/library/rust:1-bullseye                                                               1.6s
 => [stage-1 1/3] FROM docker.io/library/debian:bullseye-slim@sha256:dddc0f5f01db7ca3599fd8cf9821ffc4d09ec9d7d15e49019e73228ac1  4.6s
 => => resolve docker.io/library/debian:bullseye-slim@sha256:dddc0f5f01db7ca3599fd8cf9821ffc4d09ec9d7d15e49019e73228ac1eee7f9    0.0s
 => => sha256:312218c8dae688bae4e9d12926704fa9af6f7307a6edb4f66e479702a9af5a0c 529B / 529B                                       0.0s
 => => sha256:dd984c2cf05c58c61026b0bd2298b30aa87bca6f234db507396371137c891a6c 1.46kB / 1.46kB                                   0.0s
 => => sha256:7d63c13d9b9b6ec5f05a2b07daadacaa9c610d01102a662ae9b1d082105f1ffa 31.36MB / 31.36MB                                 2.5s
 => => sha256:dddc0f5f01db7ca3599fd8cf9821ffc4d09ec9d7d15e49019e73228ac1eee7f9 1.85kB / 1.85kB                                   0.0s
 => => extracting sha256:7d63c13d9b9b6ec5f05a2b07daadacaa9c610d01102a662ae9b1d082105f1ffa                                        1.8s
 => [internal] load build context                                                                                                0.0s
 => => transferring context: 272B                                                                                                0.0s
 => [builder 1/8] FROM docker.io/library/rust:1-bullseye@sha256:ad035009b0e1633dc85e7bdd5dc0a761f7f1bd93730b0c4027c5c9cec33ee6  28.7s
 => => resolve docker.io/library/rust:1-bullseye@sha256:ad035009b0e1633dc85e7bdd5dc0a761f7f1bd93730b0c4027c5c9cec33ee693         0.0s
 => => sha256:85a8e7ff6b81b5b88a635be4321bce975a84f6c2e25507699d9d780d6449e73f 6.42kB / 6.42kB                                   0.0s
 => => sha256:f02b617c6a8c415a175f44d7e2c5d3b521059f2a6112c5f022e005a44a759f2d 5.15MB / 5.15MB                                   1.1s
 => => sha256:ad035009b0e1633dc85e7bdd5dc0a761f7f1bd93730b0c4027c5c9cec33ee693 988B / 988B                                       0.0s
 => => sha256:1b0490ed32286c0995520b64b6b6a98cc32b6e1be44228fdd3e75a7f1105ca28 1.59kB / 1.59kB                                   0.0s
 => => sha256:bb7d5a84853b217ac05783963f12b034243070c1c9c8d2e60ada47444f3cce04 54.92MB / 54.92MB                                 3.5s
 => => sha256:d32e17419b7ee61bbd89c2f0d2833a99cf45e594257d15cb567e4cf7771ce34a 10.87MB / 10.87MB                                 2.4s
 => => sha256:c9d2d81226a43a97871acd5afb7e8aabfad4d6b62ae1709c870df3ee230bc3f5 54.57MB / 54.57MB                                 7.5s
 => => sha256:3c24ae8b66041c09dabc913b6f16fb914d5640b53b10747a343ddc5bb5bd6769 196.50MB / 196.50MB                              15.2s
 => => sha256:f64e1871528759f0207be0a9a86047cf5aa725fa78cfb1679729ac504a7158b0 133.76MB / 133.76MB                              12.8s
 => => extracting sha256:bb7d5a84853b217ac05783963f12b034243070c1c9c8d2e60ada47444f3cce04                                        2.9s
 => => extracting sha256:f02b617c6a8c415a175f44d7e2c5d3b521059f2a6112c5f022e005a44a759f2d                                        0.2s
 => => extracting sha256:d32e17419b7ee61bbd89c2f0d2833a99cf45e594257d15cb567e4cf7771ce34a                                        0.3s
 => => extracting sha256:c9d2d81226a43a97871acd5afb7e8aabfad4d6b62ae1709c870df3ee230bc3f5                                        2.8s
 => => extracting sha256:3c24ae8b66041c09dabc913b6f16fb914d5640b53b10747a343ddc5bb5bd6769                                        7.7s
 => => extracting sha256:f64e1871528759f0207be0a9a86047cf5aa725fa78cfb1679729ac504a7158b0                                        5.4s
 => [stage-1 2/3] RUN apt-get update && apt-get --yes install openssl                                                           12.2s
 => [builder 2/8] WORKDIR /usr/src/app                                                                                           0.0s
 => [builder 3/8] RUN USER=root cargo init                                                                                       0.8s
 => [builder 4/8] COPY Cargo.toml .                                                                                              0.0s
 => [builder 5/8] RUN cargo build --release                                                                                    113.6s
 => [builder 6/8] COPY src src                                                                                                   0.0s
 => [builder 7/8] COPY contracts contracts                                                                                       0.0s
 => [builder 8/8] RUN touch src/main.rs && cargo build --release                                                                 7.3s
 => [stage-1 3/3] COPY --from=builder /usr/src/app/target/release/etherbalance /bin/                                             0.0s
 => exporting to image                                                                                                           0.1s
 => => exporting layers                                                                                                          0.1s
 => => writing image sha256:c22ff3873c5134ac509854c26bb44e5fb3e1397713832b5d7ae036b18e832c39                                     0.0s
 => => naming to docker.io/library/bh2smith:etherbalance                                                                         0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
```

</details>
