### PR TITLE
depend on tokio and make main async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
  "arrayvec 0.7.1",
  "ethcontract-common",
  "ethcontract-derive",
- "futures 0.3.17",
+ "futures",
  "futures-timer",
  "hex",
  "jsonrpc-core",
@@ -444,11 +444,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ethcontract",
- "futures 0.3.17",
+ "futures",
  "prometheus",
  "rouille",
  "serde",
  "structopt",
+ "tokio",
  "toml",
  "url",
  "web3",
@@ -528,12 +529,6 @@ name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
-name = "futures"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "futures"
@@ -621,7 +616,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg",
- "futures 0.1.29",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -917,7 +911,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
 dependencies = [
- "futures 0.3.17",
+ "futures",
  "futures-executor",
  "futures-util",
  "log",
@@ -1728,7 +1722,7 @@ checksum = "4919971d141dbadaa0e82b5d369e2d7666c98e4625046140615ca363e50d4daa"
 dependencies = [
  "base64",
  "bytes",
- "futures 0.3.17",
+ "futures",
  "httparse",
  "log",
  "rand 0.8.4",
@@ -2200,7 +2194,7 @@ dependencies = [
  "derive_more",
  "ethabi",
  "ethereum-types",
- "futures 0.3.17",
+ "futures",
  "futures-timer",
  "headers",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,12 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow = "1"
 ethcontract = "0.15"
-futures = { version = "0.3", features = ["compat"] }
+futures = { version = "0.3" }
 prometheus = { version = "0.13", default-features = false }
 rouille = "3"
 serde = { version = "1", features = ["derive"] }
 structopt = "0.3"
+tokio = { version = "1.12" }
 toml = "0.5"
 url = "2"
 web3 = { version = "0.17", default-features = false, features = ["http"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,7 +169,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // update_interval makes us actually update the balances less frequently
         // than update_interval. We could be more accurate and sleep the exact
         // time needed. In practice it does not matter.
-        std::thread::sleep(opt.update_interval);
+        tokio::time::sleep(opt.update_interval).await;
     }
 }
 


### PR DESCRIPTION
We had some old errors about async rust (this was an old repo)

```
thread 'main' panicked at 'there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

Fixed by making main method async

## Test Plan

Run the program and check for metrics being recorded

```
# HELP etherbalance_last_update Unix time of last update of balances.
# TYPE etherbalance_last_update gauge
etherbalance_last_update 1634634265.007371
# HELP success_counter Success/Failure counts
# TYPE success_counter counter
success_counter{address="0x3f5ce5fbfe3e9af3971dd833d26ba9b5c936f0be",result="failure"} 6
success_counter{address="0xbe0eb53f46cd790cd13851d5eff43d12404d33e8",result="failure"} 6
```
