### PR TITLE
Add autodeploy tag

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,6 +7,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
+      AUTODEPLOY_TAG: develop
       AUTODEPLOY_URL: ${{ secrets.AUTODEPLOY_URL }}
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -14,6 +14,6 @@ if [ -n "$AUTODEPLOY_URL" ]; then
       --write-out "%{http_code}" \
       -H "Content-Type: application/json" \
       -X POST \
-      -d '{"push_data": {"tag": "'$tag_name'" }}' \
+      -d '{"push_data": {"tag": "'$AUTODEPLOY_TAG'" }}' \
       $AUTODEPLOY_URL
 fi


### PR DESCRIPTION
We set `AUTODEPLOY_TAG` to `develop` and use this to make auto deploy work. Note that we still tag the image with `master` as before so not to have any configuration changes in staging configuration.

:warning:  I do not understand how this auto deploy curl command is related to the docker image we just pushed in any way.