### PR TITLE
Handle multiple networks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "etherbalance"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/example_config.toml
+++ b/example_config.toml
@@ -1,4 +1,9 @@
-[tokens]
+[[networks]]
+# Url of ethereum node to communicate with.
+name = 'mainnet'
+url = 'http://mainnet.node'
+
+[networks.tokens]
 # A key names the address of an ERC20 token in a human readable form.
 # A value specifies the address of the token. The address is not case sensitive
 # but must start with "0x".
@@ -6,7 +11,7 @@
 usdt = "0xdac17f958d2ee523a2206206994597c13d831ec7"
 usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
 
-[addresses]
+[networks.addresses]
 # A key names the address whose balances should be monitored in a human
 # readable form.
 # * addresses is the address associated with the name.
@@ -17,3 +22,12 @@ usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
 #   address' metric.
 personal-wallet = { address = "0xbe0eb53f46cd790cd13851d5eff43d12404d33e8", ether=true, tokens = ["usdt", "usdc"], tag = "tag" }
 company-wallet = { address = "0x3f5ce5fbfe3e9af3971dd833d26ba9b5c936f0be", ether=true, tokens = ["usdt", "usdc"] }
+
+[[networks]]
+name = 'rinkeby'
+url = 'http://rinkeby.node'
+
+[networks.tokens]
+
+[networks.addresses]
+personal-wallet-rinkeby = { address = "0xbe0eb53f46cd790cd13851d5eff43d12404d33e8", ether=true, tokens = [] }

--- a/src/balance_monitor.rs
+++ b/src/balance_monitor.rs
@@ -1,7 +1,8 @@
 use crate::config;
-use anyhow::{anyhow, Error, Result};
+use anyhow::{anyhow, Context, Error, Result};
 use ethcontract::dyns::DynTransport;
 use std::{collections::HashMap, rc::Rc};
+use url::Url;
 use web3::{
     error::Error as Web3Error,
     types::{Address, U256},
@@ -10,12 +11,12 @@ use web3::{
 
 #[derive(Clone, Debug)]
 pub struct BalanceMonitor {
-    web3: web3::Web3<DynTransport>,
-    addresses: Vec<AddressToMonitor>,
+    networks: Vec<Network>,
 }
 
 #[derive(Debug)]
 pub struct CallbackParameters<'a> {
+    pub network_name: &'a str,
     pub address_name: &'a str,
     pub address: &'a Address,
     pub token_name: &'a str,
@@ -24,15 +25,35 @@ pub struct CallbackParameters<'a> {
 }
 
 impl BalanceMonitor {
-    pub fn new(config: config::Config, web3: web3::Web3<DynTransport>) -> Result<Self> {
-        if config.tokens.iter().any(|(name, _address)| name == "ether") {
+    pub fn new(config: config::Config) -> Result<Self> {
+        if config
+            .networks
+            .iter()
+            .flat_map(|network| network.tokens.iter())
+            .any(|(name, _address)| name == "ether")
+        {
             return Err(anyhow!(
                 "token name ether is cannot be used for ERC20 tokens"
             ));
         }
-        let tokens = create_tokens(config.tokens, &web3);
-        let addresses = create_addresses_to_monitor(config.addresses, &tokens)?;
-        Ok(Self { web3, addresses })
+        let networks = config
+            .networks
+            .into_iter()
+            .map(|network| {
+                let url: Url = network.url.parse().context("invalid url")?;
+                let transport =
+                    create_transport(&url).context("failed to create transport from node uri")?;
+                let web3 = web3::Web3::new(transport);
+                let tokens = create_tokens(network.tokens, &web3);
+                let addresses = create_addresses_to_monitor(network.addresses, &tokens)?;
+                Ok(Network {
+                    name: network.name,
+                    web3,
+                    addresses,
+                })
+            })
+            .collect::<Result<_>>()?;
+        Ok(Self { networks })
     }
 
     /// Retrieve all balances and call a function for each.
@@ -41,29 +62,51 @@ impl BalanceMonitor {
         T: Fn(CallbackParameters),
     {
         // TODO: batch requests
-        for address in &self.addresses {
-            if address.monitor_ether {
-                let balance = ether_balance(address.address, &self.web3.eth()).await;
-                callback(CallbackParameters {
-                    address_name: &address.name,
-                    address: &address.address,
-                    token_name: "ether",
-                    balance: balance.map_err(Error::new),
-                    tag: &address.tag,
-                });
-            }
-            for token in &address.tokens {
-                let balance = erc20_balance(&token.contract, address.address).await;
-                callback(CallbackParameters {
-                    address_name: &address.name,
-                    address: &address.address,
-                    token_name: &token.name,
-                    balance: balance.map_err(Error::new),
-                    tag: &address.tag,
-                });
+        for network in &self.networks {
+            for address in &network.addresses {
+                if address.monitor_ether {
+                    let balance = ether_balance(address.address, &network.web3.eth()).await;
+                    callback(CallbackParameters {
+                        network_name: &network.name,
+                        address_name: &address.name,
+                        address: &address.address,
+                        token_name: "ether",
+                        balance: balance.map_err(Error::new),
+                        tag: &address.tag,
+                    });
+                }
+                for token in &address.tokens {
+                    let balance = erc20_balance(&token.contract, address.address).await;
+                    callback(CallbackParameters {
+                        network_name: &network.name,
+                        address_name: &address.name,
+                        address: &address.address,
+                        token_name: &token.name,
+                        balance: balance.map_err(Error::new),
+                        tag: &address.tag,
+                    });
+                }
             }
         }
     }
+}
+
+fn create_transport(url: &Url) -> Result<DynTransport> {
+    // TODO: transport with timeouts
+    match url.scheme() {
+        "http" | "https" => {
+            let transport = web3::transports::Http::new(url.as_str())?;
+            Ok(DynTransport::new(transport))
+        }
+        other => Err(anyhow!("unknown scheme: {}", other)),
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Network {
+    name: String,
+    web3: web3::Web3<DynTransport>,
+    addresses: Vec<AddressToMonitor>,
 }
 
 ethcontract::contract!("contracts/IERC20.json");

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,9 +37,16 @@ pub struct ConfigAddress {
     pub tag: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct Network {
+    pub name: String,
+    pub url: String,
+    pub tokens: HashMap<String, Address_>,
+    pub addresses: HashMap<String, ConfigAddress>,
+}
+
 /// The user facing config file.
 #[derive(Debug, Deserialize)]
 pub struct Config {
-    pub tokens: HashMap<String, Address_>,
-    pub addresses: HashMap<String, ConfigAddress>,
+    pub networks: Vec<Network>,
 }


### PR DESCRIPTION
Currently we run multiple etherbalance binaries with different nodes. This is a common enough requirement that etherbalance should natively handle it. With this PR the config file configures not only addresses but also networks to which addresses belong.

The diff is a little easier to read without whitespace changes.

Tested manually.

Note when merging: This will break our staging setup because the config file format has changed.