### PR TITLE
Push to Github registry instead of Docker hub

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,13 +6,22 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    env:
-      AUTODEPLOY_TAG: develop
-      AUTODEPLOY_URL: ${{ secrets.AUTODEPLOY_URL }}
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      REGISTRY_URI: "gnosispm/etherbalance"
     steps:
-      - uses: actions/checkout@v2
-      - name: Deploy
-        run: docker/deploy.sh ${GITHUB_REF#refs/*/}
+      - uses: actions/checkout@v3
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}
+      - name: Image build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,15 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - id: meta
         uses: docker/metadata-action@v3
         with:
           images: ghcr.io/${{ github.repository }}
+
       - name: Image build
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
This PR enables pushing to Github Registry since the docker hub image is no longer accessible publicly.

Sample runs:
https://github.com/ahhda/etherbalance/actions/runs/8780163118
https://github.com/ahhda/etherbalance/actions/runs/8781657530